### PR TITLE
Feat: Component validator

### DIFF
--- a/weni/validators/__init__.py
+++ b/weni/validators/__init__.py
@@ -1,0 +1,3 @@
+from .validators import validate_components
+
+__all__ = ["validate_components"]

--- a/weni/validators/tests/test_validators.py
+++ b/weni/validators/tests/test_validators.py
@@ -1,0 +1,213 @@
+import pytest
+from weni.components.component import ListMessage, QuickReplies
+from weni.validators import validate_components
+from weni.components import Component, Text, Header, Footer
+
+
+def test_validate_components_valid():
+    """Test validation passes with valid components"""
+    assert validate_components([Text, Header, Footer]) is True
+
+
+def test_validate_third_party_component():
+    """Test that using a third-party component raises ValueError"""
+
+    class ThirdPartyComponent(Component):
+        pass
+
+    with pytest.raises(ValueError) as exc:
+        validate_components([ThirdPartyComponent])
+    assert "is not an official component" in str(exc.value)
+
+
+def test_validate_modified_string_attribute():
+    """Test that modifying a string attribute (even with another string) raises ValueError"""
+    original_description = Text._description
+    try:
+        Text._description = "New description"  # type: ignore
+        with pytest.raises(ValueError) as exc:
+            validate_components([Text])
+        assert "has been modified" in str(exc.value)
+        assert "Original value" in str(exc.value)
+        assert "Current value" in str(exc.value)
+    finally:
+        Text._description = original_description  # type: ignore
+
+
+def test_validate_modified_list_attribute():
+    """Test that modifying a list attribute raises ValueError"""
+    original_rules = Text._rules.copy()
+    try:
+        Text._rules = ["New rule"]  # type: ignore
+        with pytest.raises(ValueError) as exc:
+            validate_components([Text])
+        assert "has been modified" in str(exc.value)
+    finally:
+        Text._rules = original_rules  # type: ignore
+
+
+def test_validate_modified_component_lists():
+    """Test that modifying component lists raises ValueError"""
+    original_required = Text._required_components.copy()
+    try:
+        Text._required_components = [Header]  # type: ignore
+        with pytest.raises(ValueError) as exc:
+            validate_components([Text])
+        assert "has been modified" in str(exc.value)
+    finally:
+        Text._required_components = original_required  # type: ignore
+
+
+def test_empty_component_list():
+    """Test validation with empty component list"""
+    assert validate_components([]) is True
+
+
+def test_multiple_components_validation():
+    """Test validation with multiple components at once"""
+    assert validate_components([Text, Header, Footer]) is True
+
+
+def test_validate_modified_mutable_list():
+    """Test that modifying a mutable list attribute (without reassignment) raises ValueError"""
+    original_rules = Text._rules.copy()
+    try:
+        Text._rules.append("New rule")  # type: ignore
+        with pytest.raises(ValueError) as exc:
+            validate_components([Text])
+        assert "has been modified" in str(exc.value)
+    finally:
+        Text._rules = original_rules  # type: ignore
+
+
+def test_validate_nested_component_modification():
+    """Test that modifying nested component attributes raises ValueError"""
+    original_required = Text._required_components.copy()
+    original_header_desc = Header._description
+    try:
+        Text._required_components = [Header]  # type: ignore
+        Header._description = "Modified Header"  # type: ignore
+        with pytest.raises(ValueError) as exc:
+            validate_components([Text, Header])
+        assert "has been modified" in str(exc.value)
+    finally:
+        Text._required_components = original_required  # type: ignore
+        Header._description = original_header_desc  # type: ignore
+
+
+def test_validate_none_attribute():
+    """Test that setting an attribute to None raises ValueError"""
+    original_description = Text._description
+    try:
+        Text._description = None  # type: ignore
+        with pytest.raises(ValueError) as exc:
+            validate_components([Text])
+        assert "has been modified" in str(exc.value)
+    finally:
+        Text._description = original_description  # type: ignore
+
+
+def test_validate_circular_reference():
+    """Test that circular references in components are handled properly"""
+    original_allowed = Text._allowed_components.copy()
+    original_required = Header._required_components.copy()
+    try:
+        Text._allowed_components = [Header]  # type: ignore
+        Header._required_components = [Text]  # type: ignore
+        with pytest.raises(ValueError) as exc:
+            validate_components([Text, Header])
+        assert "has been modified" in str(exc.value)
+    finally:
+        Text._allowed_components = original_allowed  # type: ignore
+        Header._required_components = original_required  # type: ignore
+
+
+def test_validate_deep_copy_modification():
+    """Test that using a deep copy of a component with modifications is caught"""
+    import copy
+
+    class ModifiedComponent(Component):
+        _description = Text._description
+        _rules = copy.deepcopy(Text._rules)
+        _required_components = copy.deepcopy(Text._required_components)
+
+    ModifiedComponent._rules.append("New rule")  # type: ignore
+
+    with pytest.raises(ValueError) as exc:
+        validate_components([ModifiedComponent])
+    assert "is not an official component" in str(exc.value)
+
+
+def test_validate_list_clear():
+    """Test that clearing a list raises ValueError"""
+    original_rules = ListMessage._rules.copy()
+    try:
+        ListMessage._rules.clear()  # type: ignore
+        with pytest.raises(ValueError) as exc:
+            validate_components([ListMessage])
+        assert "has been modified" in str(exc.value)
+    finally:
+        ListMessage._rules = original_rules  # type: ignore
+
+
+def test_validate_whitespace_modification():
+    """Test that modifying whitespace in strings raises ValueError"""
+    original_description = Text._description
+    try:
+        Text._description = Text._description.strip() + " "  # type: ignore
+        with pytest.raises(ValueError) as exc:
+            validate_components([Text])
+        assert "has been modified" in str(exc.value)
+    finally:
+        Text._description = original_description  # type: ignore
+
+
+def test_validate_case_modification():
+    """Test that modifying string case raises ValueError"""
+    original_description = Text._description
+    try:
+        Text._description = Text._description.upper()  # type: ignore
+        with pytest.raises(ValueError) as exc:
+            validate_components([Text])
+        assert "has been modified" in str(exc.value)
+    finally:
+        Text._description = original_description  # type: ignore
+
+
+def test_validate_list_element_modification():
+    """Test that modifying individual list elements raises ValueError"""
+    original_rules = QuickReplies._rules.copy()
+    try:
+        if QuickReplies._rules:  # Ensure there's at least one rule
+            QuickReplies._rules[0] = QuickReplies._rules[0].upper()  # type: ignore
+        with pytest.raises(ValueError) as exc:
+            validate_components([QuickReplies])
+        assert "has been modified" in str(exc.value)
+    finally:
+        QuickReplies._rules = original_rules  # type: ignore
+
+
+def test_validate_list_slice_modification():
+    """Test that modifying list slices raises ValueError"""
+    original_rules = ListMessage._rules.copy()
+    try:
+        if len(ListMessage._rules) >= 2:
+            ListMessage._rules[0:2] = ListMessage._rules[0:2][::-1]  # type: ignore
+        with pytest.raises(ValueError) as exc:
+            validate_components([ListMessage])
+        assert "has been modified" in str(exc.value)
+    finally:
+        ListMessage._rules = original_rules  # type: ignore
+
+
+def test_validate_unicode_modification():
+    """Test that modifying strings with unicode equivalents raises ValueError"""
+    original_description = Text._description
+    try:
+        # Replace 'a' with its unicode equivalent 'а' (Cyrillic)
+        Text._description = Text._description.replace("a", "а")  # type: ignore
+        with pytest.raises(ValueError) as exc:
+            validate_components([Text])
+        assert "has been modified" in str(exc.value)
+    finally:
+        Text._description = original_description  # type: ignore

--- a/weni/validators/validators.py
+++ b/weni/validators/validators.py
@@ -1,0 +1,98 @@
+import inspect
+from typing import Type, Dict, Any
+from copy import deepcopy
+from weni.components import Component
+
+
+# Store original component values when module is loaded
+_original_components: Dict[str, Dict[str, Any]] = {}
+
+
+def _store_original_values() -> None:
+    """Store original values of all official components.
+
+    This function:
+    1. Gets all non-callable, non-private attributes from the Component class
+    2. Finds all Component subclasses in the component module
+    3. Creates deep copies of their attributes to prevent shared references
+    """
+    # Get non-private, non-callable attributes from Component class
+    component_attrs = {
+        name for name, value in vars(Component).items() if not name.startswith("__") and not callable(value)
+    }
+
+    # Get all Component subclasses from the component module
+    component_module = inspect.getmodule(Component)
+    component_classes = inspect.getmembers(component_module, inspect.isclass)
+
+    # Store deep copies of attributes for each valid component
+    for name, cls in component_classes:
+        if issubclass(cls, Component) and cls is not Component:
+            _original_components[name] = {attr: deepcopy(getattr(cls, attr)) for attr in component_attrs}
+
+
+def validate_components(components: list[Type[Component]]) -> bool:
+    """
+    Validates that component attributes haven't been modified from their original values.
+
+    Args:
+        components: List of Component classes to validate
+
+    Returns:
+        bool: True if all components are valid
+
+    Raises:
+        ValueError: If a component's attributes have been modified or if using third-party components
+    """
+    component_attrs = _get_component_attributes()
+    official_components = _get_official_components()
+
+    for component in components:
+        _validate_component_is_official(component, official_components)
+        _validate_component_attributes(component, component_attrs)
+
+    return True
+
+
+def _get_component_attributes() -> set[str]:
+    """Get non-private, non-callable attributes from Component class"""
+    return {name for name, value in vars(Component).items() if not name.startswith("__") and not callable(value)}
+
+
+def _get_official_components() -> dict[str, Type[Component]]:
+    """Get all official components defined in the component module"""
+    return {
+        name: cls
+        for name, cls in inspect.getmembers(inspect.getmodule(Component), inspect.isclass)
+        if issubclass(cls, Component) and cls is not Component
+    }
+
+
+def _validate_component_is_official(
+    component: Type[Component], official_components: dict[str, Type[Component]]
+) -> None:
+    """Validate that component is an official one"""
+    if component not in official_components.values():
+        raise ValueError(
+            f"Component {component.__name__} is not an official component. "
+            f"Only components defined in {Component.__module__} are allowed."
+        )
+
+
+def _validate_component_attributes(component: Type[Component], component_attrs: set[str]) -> None:
+    """Validate that component attributes haven't been modified"""
+    original_values = _original_components[component.__name__]
+
+    for attr_name in component_attrs:
+        current_value = getattr(component, attr_name)
+        original_value = original_values[attr_name]
+
+        if str(original_value) != str(current_value):
+            raise ValueError(
+                f"{component.__name__}.{attr_name} has been modified. "
+                f"Original value: {original_value!r}, Current value: {current_value!r}"
+            )
+
+
+# Store original values when module is loaded
+_store_original_values()


### PR DESCRIPTION
- Due to python dynamic nature, proper static immutability is nearly impossible, this function is used as a validator to add another layer of validation to ensure that provided Components are "official" ones, to prevent prompt injection in returned responses.