### PR TITLE
Feat: Any response data

### DIFF
--- a/weni/responses/responses.py
+++ b/weni/responses/responses.py
@@ -19,7 +19,7 @@ from weni.validators.validators import validate_components
 # All Reponse() calls should return a ResponseObject
 # We've added type: ignore in all return statements since __new__ return type is ignored by mypy for now
 # see https://github.com/python/mypy/issues/15182
-ResponseObject = tuple[dict[str, Any], dict[str, Any]]
+ResponseObject = tuple[Any, dict[str, Any]]
 
 
 class Response:
@@ -31,18 +31,18 @@ class Response:
     after creation.
 
     Attributes:
-        _data (dict[str, Any]): The immutable response data
+        _data (Any): The immutable response data
         _components (list[Type[Component]]): List of component types used to display the data
 
     Args:
-        data (dict[str, Any]): The response data to be returned
+        data (Any): The response data to be returned
         components (list[Type[Component]]): List of component types used for rendering
     """
 
-    _data: dict[str, Any] = {}
+    _data: Any = {}
     _components: list[Type[Component]] = []
 
-    def __new__(cls, data: dict[str, Any], components: list[Type[Component]]) -> ResponseObject:  # type: ignore
+    def __new__(cls, data: Any, components: list[Type[Component]]) -> ResponseObject:  # type: ignore
         instance = super().__new__(cls)
         instance._data = deepcopy(data)
         instance._components = deepcopy(components)
@@ -79,7 +79,7 @@ class TextResponse(Response):
     Creates a response with a text message.
 
     Args:
-        data (dict[str, Any]): The response data
+        data (Any): The response data
 
     Example:
         ```python
@@ -87,7 +87,7 @@ class TextResponse(Response):
         ```
     """
 
-    def __new__(cls, data: dict[str, Any]) -> ResponseObject:  # type: ignore
+    def __new__(cls, data: Any) -> ResponseObject:  # type: ignore
         return super().__new__(cls, data=data, components=[Text])
 
 
@@ -98,7 +98,7 @@ class AttachmentResponse(Response):
     Creates a response with attachments such as images, documents, or videos.
 
     Args:
-        data (dict[str, Any]): The response data
+        data (Any): The response data
         text (bool): Whether to include a text component (default: False)
         footer (bool): Whether to include a footer component (default: False)
 
@@ -108,7 +108,7 @@ class AttachmentResponse(Response):
         ```
     """
 
-    def __new__(cls, data: dict[str, Any], text: bool = False, footer: bool = False) -> ResponseObject:  # type: ignore
+    def __new__(cls, data: Any, text: bool = False, footer: bool = False) -> ResponseObject:  # type: ignore
         components: list[Type[Component]] = [Attachments]
 
         if text:
@@ -127,7 +127,7 @@ class QuickReplyResponse(Response):
     Creates a response with quick reply buttons and optional header/footer.
 
     Args:
-        data (dict[str, Any]): The response data
+        data (Any): The response data
         header_type (HeaderType): Type of header to display (default: HeaderType.NONE)
         footer (bool): Whether to include a footer (default: False)
 
@@ -137,7 +137,7 @@ class QuickReplyResponse(Response):
         ```
     """
 
-    def __new__(cls, data: dict[str, Any], header_type: HeaderType = HeaderType.NONE, footer: bool = False) -> ResponseObject:  # type: ignore
+    def __new__(cls, data: Any, header_type: HeaderType = HeaderType.NONE, footer: bool = False) -> ResponseObject:  # type: ignore
         components = [Text, QuickReplies]
 
         if header_type == HeaderType.TEXT:
@@ -158,7 +158,7 @@ class ListMessageResponse(Response):
     Creates a response with a list of items and optional header/footer.
 
     Args:
-        data (dict[str, Any]): The response data
+        data (Any): The response data
         header_type (HeaderType): Type of header to display (default: HeaderType.NONE)
         footer (bool): Whether to include a footer (default: False)
 
@@ -168,7 +168,7 @@ class ListMessageResponse(Response):
         ```
     """
 
-    def __new__(cls, data: dict[str, Any], header_type: HeaderType = HeaderType.NONE, footer: bool = False) -> ResponseObject:  # type: ignore
+    def __new__(cls, data: Any, header_type: HeaderType = HeaderType.NONE, footer: bool = False) -> ResponseObject:  # type: ignore
         components = [Text, ListMessage]
 
         if header_type == HeaderType.TEXT:
@@ -189,7 +189,7 @@ class CTAMessageResponse(Response):
     Creates a response with a call-to-action message and optional header/footer.
 
     Args:
-        data (dict[str, Any]): The response data
+        data (Any): The response data
         header (bool): Whether to include a header component (default: False)
         footer (bool): Whether to include a footer component (default: False)
 
@@ -199,7 +199,7 @@ class CTAMessageResponse(Response):
         ```
     """
 
-    def __new__(cls, data: dict[str, Any], header: bool = False, footer: bool = False) -> ResponseObject:  # type: ignore
+    def __new__(cls, data: Any, header: bool = False, footer: bool = False) -> ResponseObject:  # type: ignore
         components = [Text, CTAMessage]
 
         if header:
@@ -218,7 +218,7 @@ class OrderDetailsResponse(Response):
     Creates a response with order details and optional attachments/footer.
 
     Args:
-        data (dict[str, Any]): The response data
+        data (Any): The response data
         attachments (bool): Whether to include attachments (default: False)
         footer (bool): Whether to include a footer (default: False)
 
@@ -228,7 +228,7 @@ class OrderDetailsResponse(Response):
         ```
     """
 
-    def __new__(cls, data: dict[str, Any], attachments: bool = False, footer: bool = False) -> ResponseObject:  # type: ignore
+    def __new__(cls, data: Any, attachments: bool = False, footer: bool = False) -> ResponseObject:  # type: ignore
         components = [Text, OrderDetails]
 
         if attachments:
@@ -247,7 +247,7 @@ class LocationResponse(Response):
     Creates a response with a location request and optional header/footer.
 
     Args:
-        data (dict[str, Any]): The response data
+        data (Any): The response data
 
     Example:
         ```python
@@ -255,5 +255,5 @@ class LocationResponse(Response):
         ```
     """
 
-    def __new__(cls, data: dict[str, Any]) -> ResponseObject:  # type: ignore
+    def __new__(cls, data: Any) -> ResponseObject:  # type: ignore
         return super().__new__(cls, data=data, components=[Text, Location])

--- a/weni/responses/tests/test_responses.py
+++ b/weni/responses/tests/test_responses.py
@@ -496,6 +496,34 @@ def test_response_data_handling():
     assert result == {"key": "value", "nested": {"test": True}}
 
 
+def test_non_dict_response_data():
+    """Test that non-dictionary response data is handled correctly"""
+    # Test with a list
+    list_data = ["item1", "item2", "item3"]
+    result, _ = TextResponse(data=list_data)
+    assert result == ["item1", "item2", "item3"]
+
+    # Test with a string
+    string_data = "plain text data"
+    result, _ = TextResponse(data=string_data)
+    assert result == "plain text data"
+
+    # Test with a number
+    number_data = 42
+    result, _ = TextResponse(data=number_data)
+    assert result == 42
+
+    # Test with None
+    none_data = None
+    result, _ = TextResponse(data=none_data)
+    assert result is None
+
+    # Test with a boolean
+    bool_data = True
+    result, _ = TextResponse(data=bool_data)
+    assert result is True
+
+
 def test_invalid_components_exception():
     """Test that Response raises ValueError when invalid components are provided"""
 

--- a/weni/skill/skill.py
+++ b/weni/skill/skill.py
@@ -42,9 +42,6 @@ class Skill:
         instance = super().__new__(cls)
         result, format = instance.execute(context)
 
-        if not isinstance(result, dict):
-            raise TypeError(f"Execute method must return a dictionary, got {type(result)}")
-
         if not isinstance(format, dict):
             raise TypeError(f"Execute method must return a dictionary, got {type(format)}")
 

--- a/weni/skill/tests/test_skill.py
+++ b/weni/skill/tests/test_skill.py
@@ -101,26 +101,13 @@ def test_skill_without_execute_implementation():
     assert format == {"msg": {"text": "Hello, how can I help you today?"}}
 
 
-def test_skill_with_invalid_response():
-    """Test Skill with response that is not a dict"""
-
-    class InvalidSkill(Skill):
-        def execute(self, context: Context) -> ResponseObject:  # type: ignore
-            return "not a dictionary", {}  # type: ignore
-
-    context = Context(credentials={}, parameters={}, globals={})
-
-    with pytest.raises(TypeError) as excinfo:
-        InvalidSkill(context)
-
-    assert "Execute method must return a dictionary" in str(excinfo.value)
-
-
 def test_skill_with_invalid_format():
-    """Test Skill with format that is not a dict"""
+    """Test Skill where the format value (second return value) is not a dict"""
 
     class InvalidFormatSkill(Skill):
         def execute(self, context: Context) -> ResponseObject:  # type: ignore
+            # The first value can be any type (a dictionary here),
+            # but the second value (format) must be a dictionary - not a string
             return {}, "not a dictionary"  # type: ignore
 
     context = Context(credentials={}, parameters={}, globals={})
@@ -207,3 +194,35 @@ def test_skill_with_complex_response():
             "footer": "Powered by Weni",
         }
     }
+
+
+def test_skill_with_non_dict_response():
+    """Test Skill execution with non-dictionary response data"""
+
+    class ListDataSkill(Skill):
+        def execute(self, context: Context) -> ResponseObject:
+            return TextResponse(data=["item1", "item2", "item3"])  # type: ignore
+
+    context = Context(credentials={}, parameters={}, globals={})
+    result, format = ListDataSkill(context)
+
+    assert result == ["item1", "item2", "item3"]
+    assert format == {"msg": {"text": "Hello, how can I help you today?"}}
+
+    class StringDataSkill(Skill):
+        def execute(self, context: Context) -> ResponseObject:
+            return TextResponse(data="simple string response")  # type: ignore
+
+    result, format = StringDataSkill(context)
+
+    assert result == "simple string response"
+    assert format == {"msg": {"text": "Hello, how can I help you today?"}}
+
+    class NumberDataSkill(Skill):
+        def execute(self, context: Context) -> ResponseObject:
+            return TextResponse(data=42)  # type: ignore
+
+    result, format = NumberDataSkill(context)
+
+    assert result == 42
+    assert format == {"msg": {"text": "Hello, how can I help you today?"}}


### PR DESCRIPTION
- Eliminate the type check for the result of the execute method in the Skill class
- Ensure that only the format return type is validated, maintaining focus on expected output structure
- Change type hints for response data in Response class and its subclasses from `dict[str, Any]` to `Any`