### PR TITLE
refactor: rename Skill to Tool and update related components

### DIFF
--- a/weni/__init__.py
+++ b/weni/__init__.py
@@ -1,16 +1,16 @@
 """
 Weni Agents Toolkit
 
-A Python library for creating and managing skills for the Weni platform.
+A Python library for creating and managing tools for the Weni platform.
 """
 
-from weni.skill import Skill
+from weni.tool import Tool
 from weni.context import Context
 import weni.components as Components
 import weni.responses as Responses
 
 __all__ = [
-    "Skill",
+    "Tool",
     "Context",
     "Components",
     "Responses",

--- a/weni/components/component.py
+++ b/weni/components/component.py
@@ -6,7 +6,7 @@ class Component:
     Base class for all components.
 
     Components define the structure and rules for different types of elements
-    that can be used to display skill responses. Component attributes are
+    that can be used to display tool responses. Component attributes are
     immutable class variables.
 
     Class Attributes:

--- a/weni/context/context.py
+++ b/weni/context/context.py
@@ -4,14 +4,14 @@ from typing import Mapping
 
 class Context:
     """
-    An immutable context container for skill execution.
+    An immutable context container for tool execution.
 
     The Context class provides a thread-safe, immutable container for passing data
-    to skills during execution. It contains three separate namespaces:
+    to tools during execution. It contains three separate namespaces:
 
     Attributes:
         credentials (Mapping): Immutable mapping for configured secrets data
-        parameters (Mapping): Immutable mapping for skill-specific parameters
+        parameters (Mapping): Immutable mapping for tool-specific parameters
         globals (Mapping): Immutable mapping for global configuration values
     """
 

--- a/weni/responses/responses.py
+++ b/weni/responses/responses.py
@@ -24,9 +24,9 @@ ResponseObject = tuple[Any, dict[str, Any]]
 
 class Response:
     """
-    Base class for all skill response types.
+    Base class for all tool response types.
 
-    A Response encapsulates both the data returned by a skill and the components
+    A Response encapsulates both the data returned by a tool and the components
     used to display that data. All response data and components are immutable
     after creation.
 

--- a/weni/skill/__init__.py
+++ b/weni/skill/__init__.py
@@ -1,3 +1,0 @@
-from .skill import Skill
-
-__all__ = ["Skill"]

--- a/weni/tool/__init__.py
+++ b/weni/tool/__init__.py
@@ -1,0 +1,3 @@
+from .tool import Tool
+
+__all__ = ["Tool"]

--- a/weni/tool/tool.py
+++ b/weni/tool/tool.py
@@ -2,18 +2,18 @@ from weni.context import Context
 from weni.responses import ResponseObject, TextResponse
 
 
-class Skill:
+class Tool:
     """
-    Base class for implementing skills.
+    Base class for implementing tools.
 
-    A skill represents a specific capability or functionality that can be executed within the platform.
-    Skills receive a Context object containing credentials, parameters and global variables, and must
+    A tool represents a specific capability or functionality that can be executed within the platform.
+    Tools receive a Context object containing credentials, parameters and global variables, and must
     return a Response object with the execution result and the components that should be used to
     display it.
 
     Example:
         ```python
-        class GetWeather(Skill):
+        class GetWeather(Tool):
             def execute(self, context: Context) -> Response:
                 # Get API key from credentials
                 api_key = context.credentials.get("weather_api_key")
@@ -31,11 +31,11 @@ class Skill:
                 )
         ```
 
-    The skill execution flow is:
-    1. The skill receives a Context object with credentials, parameters and globals
+    The tool execution flow is:
+    1. The tool receives a Context object with credentials, parameters and globals
     2. The execute() method is called with the context
-    3. The skill performs its business logic using the context data
-    4. The skill returns a Response with the result data and display components
+    3. The tool performs its business logic using the context data
+    4. The tool returns a Response with the result data and display components
     """
 
     def __new__(cls, context: Context):
@@ -49,9 +49,9 @@ class Skill:
 
     def execute(self, context: Context) -> ResponseObject:
         """
-        Execute the skill's main functionality.
+        Execute the tool's main functionality.
 
-        This method should be overridden by subclasses to implement the skill's
+        This method should be overridden by subclasses to implement the tool's
         specific behavior. The default implementation returns an empty TextResponse.
 
         Args:


### PR DESCRIPTION
- Replace all instances of "Skill" with "Tool" in the codebase to reflect the new terminology.
- Update the Context and Response classes to refer to tool execution instead of skill execution.
- Introduce a new Tool class that serves as a base for implementing specific capabilities within the platform.
- Add tests for the Tool class to ensure proper execution and response handling.