### PR TITLE
docs: update terminology from "Skill" to "Tool" across documentation

### DIFF
--- a/docs/getting-started/core-concepts.md
+++ b/docs/getting-started/core-concepts.md
@@ -1,21 +1,21 @@
 # Core Concepts
 
-## Skills
+## Tools
 
-Skills are the fundamental building blocks of the Weni Agents Toolkit. Each skill is a self-contained unit of functionality that can:
+Tools are the fundamental building blocks of the Weni Agents Toolkit. Each tool is a self-contained unit of functionality that can:
 
 - Process user input
 - Execute business logic
 - Generate appropriate responses with context for the AI agent
 
 ```python
-from weni import Skill
+from weni import Tool
 from weni.context import Context
 from weni.responses import TextResponse
 
-class WeatherSkill(Skill):
+class WeatherTool(Tool):
     def execute(self, context: Context) -> TextResponse:
-        # Skill implementation that returns context for the AI agent
+        # Tool implementation that returns context for the AI agent
         city = context.parameters.get("city", "")
         weather_data = self._fetch_weather(city)
         
@@ -29,12 +29,12 @@ class WeatherSkill(Skill):
 
 ## Context System
 
-The Context system provides a secure, immutable container for passing data to skills:
+The Context system provides a secure, immutable container for passing data to tools:
 
 ```python
 context = Context(
     credentials={"api_key": "secret123"},     # Sensitive data
-    parameters={"city": "New York"},          # Skill parameters
+    parameters={"city": "New York"},          # Tool parameters
     globals={"api_url": "https://api.example.com"}  # Global configuration
 )
 ```
@@ -63,7 +63,7 @@ response = QuickReplyResponse(
 
 ## Key Principles
 
-1. **Skills** are responsible for:
+1. **Tools** are responsible for:
    - Processing inputs
    - Executing business logic
    - Gathering relevant context
@@ -71,7 +71,7 @@ response = QuickReplyResponse(
 
 2. **Context** provides:
    - Secure credential storage
-   - Skill-specific parameters
+   - Tool-specific parameters
    - Global configuration
    - Immutable data access
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,15 +1,15 @@
 # Quick Start
 
-## Creating Your First Skill
+## Creating Your First Tool
 
-Let's create a simple greeting skill that provides user context:
+Let's create a simple greeting tool that provides user context:
 
 ```python
-from weni import Skill
+from weni import Tool
 from weni.context import Context
 from weni.responses import TextResponse
 
-class GreetingSkill(Skill):
+class GreetingTool(Tool):
     def execute(self, context: Context) -> TextResponse:
         name = context.parameters.get("name", "Guest")
         time_of_day = self._get_time_of_day()
@@ -24,12 +24,12 @@ class GreetingSkill(Skill):
 
 ## Using Quick Replies
 
-Here's how to create a skill that provides context for decision-making:
+Here's how to create a tool that provides context for decision-making:
 
 ```python
 from weni.responses import QuickReplyResponse
 
-class ConfirmationSkill(Skill):
+class ConfirmationTool(Tool):
     def execute(self, context: Context) -> QuickReplyResponse:
         order_id = context.parameters.get("order_id")
         order_details = self._get_order_details(order_id)
@@ -54,11 +54,11 @@ class ConfirmationSkill(Skill):
 
 The Context object provides access to:
 - Credentials (API keys, tokens)
-- Parameters (skill-specific inputs)
+- Parameters (tool-specific inputs)
 - Globals (project-wide settings)
 
 ```python
-class WeatherSkill(Skill):
+class WeatherTool(Tool):
     def execute(self, context: Context) -> TextResponse:
         # Access API key from credentials
         api_key = context.credentials.get("weather_api_key")
@@ -99,4 +99,4 @@ class WeatherSkill(Skill):
 - Understand the [Context System](../user-guide/context.md)
 
 !!! tip "Context is Key"
-    Remember that skills should provide rich, structured context data that helps the AI agent generate appropriate responses. The more relevant context you provide, the better the AI can understand the situation and respond accordingly. 
+    Remember that tools should provide rich, structured context data that helps the AI agent generate appropriate responses. The more relevant context you provide, the better the AI can understand the situation and respond accordingly. 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,12 @@
 # Weni Agents Toolkit
 
-A Python library for creating and managing agent skills for the Weni platform. Build powerful conversational agents with type-safe components and a robust skill system.
+A Python library for creating and managing agent tools for the Weni platform. Build powerful conversational agents with type-safe components and a robust tool system.
 
 ## Features
 
-- 🔒 **Type-safe Skills**: Build reliable skills with type checking and validation
+- 🔒 **Type-safe Tools**: Build reliable tools with type checking and validation
 - 🛡️ **Immutable Context**: Secure handling of credentials and configuration
-- 🧩 **Modular Architecture**: Easily extend and customize skills
+- 🧩 **Modular Architecture**: Easily extend and customize tools
 - 📝 **Rich Context**: Comprehensive data structures for AI understanding
 - ✨ **Built-in Validation**: Automatic validation of responses and data
 - 🔌 **Response System**: Simple and intuitive context creation
@@ -26,11 +26,11 @@ A Python library for creating and managing agent skills for the Weni platform. B
 ## Quick Example
 
 ```python
-from weni import Skill
+from weni import Tool
 from weni.context import Context
 from weni.responses import TextResponse
 
-class GreetingSkill(Skill):
+class GreetingTool(Tool):
     def execute(self, context: Context) -> TextResponse:
         # Get user information from context
         name = context.parameters.get("name", "Guest")

--- a/docs/user-guide/context.md
+++ b/docs/user-guide/context.md
@@ -1,24 +1,24 @@
 # Context System
 
-The Context system is a fundamental part of the Weni Agents Toolkit, providing a secure and immutable way for skills to access data they need during execution.
+The Context system is a fundamental part of the Weni Agents Toolkit, providing a secure and immutable way for tools to access data they need during execution.
 
 ## Overview
 
-When a skill's `execute` method is called, it receives a Context object containing three main sections:
+When a tool's `execute` method is called, it receives a Context object containing three main sections:
 - **credentials**: Secure storage for sensitive data like API keys
-- **parameters**: Skill-specific input parameters
+- **parameters**: Tool-specific input parameters
 - **globals**: Project-wide configuration values
 
-## Using Context in Skills
+## Using Context in Tools
 
 ### Basic Context Usage
 
 ```python
-from weni import Skill
+from weni import Tool
 from weni.context import Context
 from weni.responses import TextResponse
 
-class WeatherSkill(Skill):
+class WeatherTool(Tool):
     def execute(self, context: Context) -> TextResponse:
         # Access API credentials securely
         api_key = context.credentials.get("weather_api_key", "")
@@ -43,7 +43,7 @@ class WeatherSkill(Skill):
 Always use the `get()` method to safely access data with defaults:
 
 ```python
-class OrderSkill(Skill):
+class OrderTool(Tool):
     def execute(self, context: Context) -> TextResponse:
         # Safe access with defaults
         user_id = context.parameters.get("user_id", "anonymous")
@@ -58,7 +58,7 @@ Use type hints for better code safety:
 ```python
 from typing import Optional, Any
 
-class ProfileSkill(Skill):
+class ProfileTool(Tool):
     def execute(self, context: Context) -> TextResponse:
         user_id: str = context.parameters.get("user_id", "")
         settings: dict[str, Any] = context.globals.get("settings", {})

--- a/docs/user-guide/tools.md
+++ b/docs/user-guide/tools.md
@@ -1,29 +1,29 @@
-# Skills
+# Tools
 
 ## Overview
 
-Skills are the core executable units in the Weni Agents Toolkit. They encapsulate specific functionality and can be combined to create complex conversational flows.
+Tools are the core executable units in the Weni Agents Toolkit. They encapsulate specific functionality and can be combined to create complex conversational flows.
 
-## Creating a Skill
+## Creating a Tool
 
 ```python
-from weni import Skill
+from weni import Tool
 from weni.context import Context
 from weni.responses import TextResponse
 from typing import Optional
 
-class CustomSkill(Skill):
+class CustomTool(Tool):
     def execute(self, context: Context) -> TextResponse:
         # Implementation here
         pass
 ```
 
-## Skill Lifecycle
+## Tool Lifecycle
 
-1. **Initialization**: Skill instance is created
-2. **Context Reception**: Skill receives execution context
+1. **Initialization**: Tool instance is created
+2. **Context Reception**: Tool receives execution context
 3. **Execution**: Business logic is processed
-4. **Response Generation**: Skill generates appropriate response
+4. **Response Generation**: Tool generates appropriate response
 
 ## Best Practices
 
@@ -34,7 +34,7 @@ Always use type hints:
 ```python
 from typing import Any
 
-class WeatherSkill(Skill):
+class WeatherTool(Tool):
     def execute(self, context: Context) -> Response:
         location: str = context.parameters.get("location", "")
         return TextResponse(data=self._get_weather(location))
@@ -49,9 +49,9 @@ class WeatherSkill(Skill):
 Always return a response, even if it's an error response, this will allow the AI to continue the conversation:
 
 ```python
-from weni.exceptions import SkillError
+from weni.exceptions import ToolError
 
-class APISkill(Skill):
+class APITool(Tool):
     def execute(self, context: Context) -> Response:
         try:
             # API call


### PR DESCRIPTION
- Replace all instances of "Skill" with "Tool" in the documentation to align with recent terminology changes.
- Update examples and descriptions to reflect the new focus on tools, including context usage and best practices.
- Introduce a new section on tools to provide an overview and guidelines for creating and using them effectively.