### PR TITLE
feat: add OneClickPayment and WhatsAppFlows message types with dict shorthand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [2.6.1] - 2026-04-07
 
-- feat: new-messages
+- feat: add OneClickPayment and WhatsAppFlows message types with dict shorthand
 
 ## [2.6.0] - 2026-04-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+
+## [2.6.1] - 2026-04-07
+
+- feat: new-messages
+
 ## [2.6.0] - 2026-04-02
 
 - refactor: get events

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "weni-agents-toolkit"
-version = "2.6.0"
+version = "2.6.1"
 description = ""
 authors = ["Paulo Bernardo <paulo.bernardo@weni.ai>"]
 readme = "README.md"

--- a/weni/broadcasts/__init__.py
+++ b/weni/broadcasts/__init__.py
@@ -1,12 +1,15 @@
 from weni.broadcasts.broadcast import Broadcast
 from weni.broadcasts.messages import (
     Message,
+    OneClickPayment,
+    OrderItem,
     QuickReply,
     Text,
     WebChatProduct,
     WebChatProductGroup,
     WeniWebChatCatalog,
     WhatsAppCatalog,
+    WhatsAppFlows,
     WhatsAppProductGroup,
 )
 from weni.broadcasts.sender import (
@@ -31,4 +34,7 @@ __all__ = [
     "WebChatProduct",
     "WhatsAppCatalog",
     "WhatsAppProductGroup",
+    "OneClickPayment",
+    "OrderItem",
+    "WhatsAppFlows",
 ]

--- a/weni/broadcasts/messages.py
+++ b/weni/broadcasts/messages.py
@@ -155,7 +155,7 @@ class WeniWebChatCatalog(Message):
     """
 
     text: str
-    products: list[WebChatProductGroup | dict] = field(default_factory=list)
+    products: list[WebChatProductGroup] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         self.products = [
@@ -237,7 +237,7 @@ class WhatsAppCatalog(Message):
     """
 
     text: str
-    products: list[WhatsAppProductGroup | dict] = field(default_factory=list)
+    products: list[WhatsAppProductGroup] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         self.products = [
@@ -306,7 +306,7 @@ class OneClickPayment(Message):
     last_four_digits: str
     credential_id: str
     total_amount: int
-    items: list[OrderItem | dict] = field(default_factory=list)
+    items: list[OrderItem] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         self.items = [

--- a/weni/broadcasts/messages.py
+++ b/weni/broadcasts/messages.py
@@ -370,6 +370,7 @@ class WhatsAppFlows(Message):
             flow_id="1451561746318256",
             flow_cta="Confirm Now",
             flow_screen="COLLECT_DATA",
+            flow_token="1234567890",
             flow_data={"order_value": "R$ 150,00"},
         ))
         ```
@@ -379,6 +380,7 @@ class WhatsAppFlows(Message):
     flow_id: str
     flow_cta: str
     flow_screen: str
+    flow_token: str | None = None
     flow_data: dict[str, Any] = field(default_factory=dict)
     flow_mode: str = "published"
 
@@ -391,6 +393,7 @@ class WhatsAppFlows(Message):
                 "flow_cta": self.flow_cta,
                 "flow_mode": self.flow_mode,
                 "flow_screen": self.flow_screen,
+                "flow_token": self.flow_token,
                 "flow_data": self.flow_data,
             },
         }

--- a/weni/broadcasts/messages.py
+++ b/weni/broadcasts/messages.py
@@ -122,6 +122,7 @@ class WebChatProduct:
     description: str | None = None
     image: str | None = None
     sale_price: str | None = None
+    product_url: str | None = None
 
 
 @dataclass
@@ -137,24 +138,35 @@ class WeniWebChatCatalog(Message):
     """
     Catalog message for Weni WebChat with full product details.
 
+    Products can be passed as dicts — no need to import WebChatProductGroup/WebChatProduct.
+
     Example:
         ```python
         Broadcast(self).send(WeniWebChatCatalog(
             text="Here are our products",
-            products=[
-                WebChatProductGroup(
-                    product="Shirts",
-                    product_retailer_info=[
-                        WebChatProduct(name="Blue Shirt", price="149.90", retailer_id="85961", seller_id="1"),
-                    ]
-                )
-            ],
+            products=[{
+                "product": "Shirts",
+                "product_retailer_info": [
+                    {"name": "Blue Shirt", "price": "149.90", "retailer_id": "85961", "seller_id": "1"},
+                ],
+            }],
         ))
         ```
     """
 
     text: str
-    products: list[WebChatProductGroup] = field(default_factory=list)
+    products: list[WebChatProductGroup | dict] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self.products = [
+            WebChatProductGroup(
+                product=group["product"],
+                product_retailer_info=[
+                    WebChatProduct(**product) for product in group.get("product_retailer_info", [])
+                ],
+            ) if isinstance(group, dict) else group
+            for group in self.products
+        ]
     action_button_text: str = "Comprar"
     send_catalog: bool = False
     header: str | None = None
@@ -178,6 +190,8 @@ class WeniWebChatCatalog(Message):
                     product_dict["image"] = item.image
                 if item.sale_price:
                     product_dict["sale_price"] = item.sale_price
+                if item.product_url:
+                    product_dict["product_url"] = item.product_url
                 items.append(product_dict)
             product_groups.append({
                 "product": group.product,
@@ -209,22 +223,27 @@ class WhatsAppCatalog(Message):
     """
     Catalog message for WhatsApp with product retailer IDs.
 
+    Products can be passed as dicts — no need to import WhatsAppProductGroup.
+
     Example:
         ```python
         Broadcast(self).send(WhatsAppCatalog(
             text="Here are our shirts",
             products=[
-                WhatsAppProductGroup(
-                    product="Workshirt Titan Coyote",
-                    product_retailer_ids=["12552#1#1", "12553#1#1"],
-                ),
+                {"product": "Workshirt Titan Coyote", "product_retailer_ids": ["12552#1#1", "12553#1#1"]},
             ],
         ))
         ```
     """
 
     text: str
-    products: list[WhatsAppProductGroup] = field(default_factory=list)
+    products: list[WhatsAppProductGroup | dict] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self.products = [
+            WhatsAppProductGroup(**group) if isinstance(group, dict) else group
+            for group in self.products
+        ]
     action_button_text: str = "Comprar"
     send_catalog: bool = False
     header: str | None = None
@@ -248,3 +267,130 @@ class WhatsAppCatalog(Message):
         }
         self._apply_header_footer(payload, self.header, self.footer)
         return payload
+
+
+@dataclass
+class OrderItem:
+    """A single item in a one-click payment order."""
+
+    retailer_id: str
+    name: str
+    amount: int
+    quantity: int = 1
+    sale_amount: int | None = None
+
+
+@dataclass
+class OneClickPayment(Message):
+    """
+    One-click payment message with saved card details.
+
+    Items can be passed as dicts — no need to import OrderItem.
+
+    Example:
+        ```python
+        Broadcast(self).send(OneClickPayment(
+            text="Use this card to pay?",
+            reference_id="ORDER-123",
+            last_four_digits="4242",
+            credential_id="acc_001",
+            total_amount=15000,
+            items=[{"retailer_id": "SKU-1", "name": "Shirt", "amount": 15000}],
+            subtotal=15000,
+        ))
+        ```
+    """
+
+    text: str
+    reference_id: str
+    last_four_digits: str
+    credential_id: str
+    total_amount: int
+    items: list[OrderItem | dict] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self.items = [
+            OrderItem(**item) if isinstance(item, dict) else item
+            for item in self.items
+        ]
+    subtotal: int = 0
+    tax_value: int = 0
+    discount_value: int = 0
+    shipping_value: int = 0
+
+    def format_message(self) -> dict[str, Any]:
+        order_items = []
+        for item in self.items:
+            item_dict: dict[str, Any] = {
+                "retailer_id": item.retailer_id,
+                "name": item.name,
+                "amount": {"value": item.amount, "offset": 100},
+                "quantity": item.quantity,
+            }
+            if item.sale_amount is not None:
+                item_dict["sale_amount"] = {"value": item.sale_amount, "offset": 100}
+            order_items.append(item_dict)
+
+        order: dict[str, Any] = {
+            "items": order_items,
+            "subtotal": self.subtotal,
+            "tax": {"description": "Impostos", "offset": 100, "value": self.tax_value},
+            "discount": {"description": "Desconto", "offset": 100, "value": self.discount_value},
+            "shipping": {"description": "Frete", "offset": 100, "value": self.shipping_value},
+        }
+
+        return {
+            "text": self.text,
+            "interaction_type": "order_details",
+            "order_details": {
+                "reference_id": self.reference_id,
+                "type": "digital-goods",
+                "payment_settings": {
+                    "type": "offsite_card_pay",
+                    "offsite_card_pay": {
+                        "last_four_digits": str(self.last_four_digits),
+                        "credential_id": str(self.credential_id),
+                    },
+                },
+                "total_amount": self.total_amount,
+                "order": order,
+            },
+        }
+
+
+@dataclass
+class WhatsAppFlows(Message):
+    """
+    WhatsApp Flows interactive message.
+
+    Example:
+        ```python
+        Broadcast(self).send(WhatsAppFlows(
+            text="You have a pending confirmation.",
+            flow_id="1451561746318256",
+            flow_cta="Confirm Now",
+            flow_screen="COLLECT_DATA",
+            flow_data={"order_value": "R$ 150,00"},
+        ))
+        ```
+    """
+
+    text: str
+    flow_id: str
+    flow_cta: str
+    flow_screen: str
+    flow_data: dict[str, Any] = field(default_factory=dict)
+    flow_mode: str = "published"
+
+    def format_message(self) -> dict[str, Any]:
+        return {
+            "text": self.text,
+            "interaction_type": "flow_msg",
+            "flow_message": {
+                "flow_id": self.flow_id,
+                "flow_cta": self.flow_cta,
+                "flow_mode": self.flow_mode,
+                "flow_screen": self.flow_screen,
+                "flow_data": self.flow_data,
+            },
+        }

--- a/weni/broadcasts/tests/test_messages.py
+++ b/weni/broadcasts/tests/test_messages.py
@@ -10,6 +10,9 @@ from weni.broadcasts.messages import (
     WebChatProductGroup,
     WhatsAppCatalog,
     WhatsAppProductGroup,
+    OneClickPayment,
+    OrderItem,
+    WhatsAppFlows,
 )
 
 class TestTextMessage:
@@ -163,3 +166,150 @@ class TestWhatsAppCatalog:
         assert payload["footer"] == "All UV protected"
         assert payload["catalog_message"]["action_button_text"] == "Buy now"
         assert len(payload["catalog_message"]["products"]) == 2
+
+
+class TestOneClickPayment:
+    def test_format_basic(self):
+        msg = OneClickPayment(
+            text="Use this card to pay?",
+            reference_id="ORDER-123",
+            last_four_digits="4242",
+            credential_id="acc_001",
+            total_amount=15000,
+            items=[OrderItem(retailer_id="SKU-1", name="Shirt", amount=15000)],
+            subtotal=15000,
+        )
+        payload = msg.format_message()
+
+        assert payload["text"] == "Use this card to pay?"
+        assert payload["interaction_type"] == "order_details"
+
+        details = payload["order_details"]
+        assert details["reference_id"] == "ORDER-123"
+        assert details["type"] == "digital-goods"
+        assert details["total_amount"] == 15000
+
+        payment = details["payment_settings"]
+        assert payment["type"] == "offsite_card_pay"
+        assert payment["offsite_card_pay"]["last_four_digits"] == "4242"
+        assert payment["offsite_card_pay"]["credential_id"] == "acc_001"
+
+        order = details["order"]
+        assert len(order["items"]) == 1
+        assert order["items"][0]["retailer_id"] == "SKU-1"
+        assert order["items"][0]["name"] == "Shirt"
+        assert order["items"][0]["amount"] == {"value": 15000, "offset": 100}
+        assert order["items"][0]["quantity"] == 1
+        assert order["subtotal"] == 15000
+        assert order["tax"]["value"] == 0
+        assert order["discount"]["value"] == 0
+        assert order["shipping"]["value"] == 0
+
+    def test_format_with_all_fields(self):
+        msg = OneClickPayment(
+            text="Confirm payment?",
+            reference_id="REF-456",
+            last_four_digits="1234",
+            credential_id="acc_002",
+            total_amount=25000,
+            items=[
+                OrderItem(retailer_id="SKU-1", name="Product A", amount=10000, quantity=2),
+                OrderItem(retailer_id="SKU-2", name="Product B", amount=5000, sale_amount=4000),
+            ],
+            subtotal=25000,
+            tax_value=500,
+            discount_value=1000,
+            shipping_value=800,
+        )
+        payload = msg.format_message()
+
+        order = payload["order_details"]["order"]
+        assert len(order["items"]) == 2
+        assert order["items"][0]["quantity"] == 2
+        assert "sale_amount" not in order["items"][0]
+        assert order["items"][1]["sale_amount"] == {"value": 4000, "offset": 100}
+        assert order["tax"]["value"] == 500
+        assert order["discount"]["value"] == 1000
+        assert order["shipping"]["value"] == 800
+
+
+class TestWhatsAppFlows:
+    def test_format_basic(self):
+        msg = WhatsAppFlows(
+            text="You have a pending confirmation.",
+            flow_id="1451561746318256",
+            flow_cta="Confirm Now",
+            flow_screen="COLLECT_DATA",
+        )
+        payload = msg.format_message()
+
+        assert payload["text"] == "You have a pending confirmation."
+        assert payload["interaction_type"] == "flow_msg"
+
+        flow = payload["flow_message"]
+        assert flow["flow_id"] == "1451561746318256"
+        assert flow["flow_cta"] == "Confirm Now"
+        assert flow["flow_mode"] == "published"
+        assert flow["flow_screen"] == "COLLECT_DATA"
+        assert flow["flow_data"] == {}
+
+    def test_format_with_data(self):
+        msg = WhatsAppFlows(
+            text="Confirm your order",
+            flow_id="123456",
+            flow_cta="Confirm",
+            flow_screen="ORDER_SCREEN",
+            flow_data={"order_value": "R$ 150,00", "card_last_four": "1234"},
+            flow_mode="draft",
+        )
+        payload = msg.format_message()
+
+        flow = payload["flow_message"]
+        assert flow["flow_data"] == {"order_value": "R$ 150,00", "card_last_four": "1234"}
+        assert flow["flow_mode"] == "draft"
+
+
+class TestDictShorthand:
+    """Tests that all message types accept dicts instead of dataclass imports."""
+
+    def test_webchat_catalog_with_dicts(self):
+        msg = WeniWebChatCatalog(
+            text="Products",
+            products=[{
+                "product": "Shirts",
+                "product_retailer_info": [
+                    {"name": "Blue Shirt", "price": "149.90", "retailer_id": "85961", "seller_id": "1"},
+                ],
+            }],
+        )
+        payload = msg.format_message()
+
+        assert payload["catalog_message"]["products"][0]["product"] == "Shirts"
+        assert payload["catalog_message"]["products"][0]["product_retailer_info"][0]["name"] == "Blue Shirt"
+
+    def test_whatsapp_catalog_with_dicts(self):
+        msg = WhatsAppCatalog(
+            text="Shirts",
+            products=[
+                {"product": "Titan Coyote", "product_retailer_ids": ["12552#1#1"]},
+            ],
+        )
+        payload = msg.format_message()
+
+        assert payload["catalog_message"]["products"][0]["product"] == "Titan Coyote"
+        assert payload["catalog_message"]["products"][0]["product_retailer_ids"] == ["12552#1#1"]
+
+    def test_one_click_payment_with_dicts(self):
+        msg = OneClickPayment(
+            text="Pay now?",
+            reference_id="ORDER-1",
+            last_four_digits="4242",
+            credential_id="acc_1",
+            total_amount=10000,
+            items=[{"retailer_id": "SKU-1", "name": "Shirt", "amount": 10000}],
+            subtotal=10000,
+        )
+        payload = msg.format_message()
+
+        assert payload["order_details"]["order"]["items"][0]["retailer_id"] == "SKU-1"
+        assert payload["order_details"]["order"]["items"][0]["amount"] == {"value": 10000, "offset": 100}

--- a/weni/broadcasts/tests/test_messages.py
+++ b/weni/broadcasts/tests/test_messages.py
@@ -251,7 +251,19 @@ class TestWhatsAppFlows:
         assert flow["flow_cta"] == "Confirm Now"
         assert flow["flow_mode"] == "published"
         assert flow["flow_screen"] == "COLLECT_DATA"
+        assert flow["flow_token"] is None
         assert flow["flow_data"] == {}
+
+    def test_format_with_token(self):
+        msg = WhatsAppFlows(
+            text="Confirm",
+            flow_id="123",
+            flow_cta="Go",
+            flow_screen="SCREEN",
+            flow_token="tok_abc123",
+        )
+        payload = msg.format_message()
+        assert payload["flow_message"]["flow_token"] == "tok_abc123"
 
     def test_format_with_data(self):
         msg = WhatsAppFlows(


### PR DESCRIPTION
# feat: add OneClickPayment and WhatsAppFlows message types with dict shorthand

## Summary

Adds two new broadcast message types and introduces dict shorthand across all catalog/payment messages, so developers no longer need to import auxiliary dataclasses.

## New Message Types

### OneClickPayment

Sends an order confirmation with a saved card for one-click payment via WhatsApp.

```python
from weni.broadcasts import OneClickPayment

self.send_broadcast(OneClickPayment(
    text="Use this card to pay?",
    reference_id="ORDER-123",
    last_four_digits="4242",
    credential_id="acc_001",
    total_amount=15000,
    items=[{"retailer_id": "SKU-1", "name": "Shirt", "amount": 15000}],
    subtotal=15000,
    tax_value=500,
    discount_value=0,
    shipping_value=800,
))
```

Generates `interaction_type: "order_details"` with `payment_settings.type: "offsite_card_pay"`.

### WhatsAppFlows

Sends a WhatsApp Flows interactive message that opens a structured flow screen.

```python
from weni.broadcasts import WhatsAppFlows

self.send_broadcast(WhatsAppFlows(
    text="You have a pending confirmation.",
    flow_id="1451561746318256",
    flow_cta="Confirm Now",
    flow_screen="COLLECT_DATA",
    flow_data={"order_value": "R$ 150,00", "card_last_four": "1234"},
))
```

Generates `interaction_type: "flow_msg"` with `flow_message` payload.

## Dict Shorthand

All message types that accept nested objects (`WeniWebChatCatalog`, `WhatsAppCatalog`, `OneClickPayment`) now accept plain dicts instead of requiring imported dataclasses.

Before (required extra imports):
```python
from weni.broadcasts import OneClickPayment, OrderItem

OneClickPayment(
    ...,
    items=[OrderItem(retailer_id="SKU-1", name="Shirt", amount=15000)],
)
```

After (just dicts):
```python
from weni.broadcasts import OneClickPayment

OneClickPayment(
    ...,
    items=[{"retailer_id": "SKU-1", "name": "Shirt", "amount": 15000}],
)
```

Dicts are auto-converted via `__post_init__`. Passing dataclass instances directly still works (backward compatible).

## Other Changes

- Added `product_url` field to `WebChatProduct` for linking products to their store page

## Files Changed

| File | Change |
|------|--------|
| `weni/broadcasts/messages.py` | Added `OneClickPayment`, `OrderItem`, `WhatsAppFlows`. Added `__post_init__` dict conversion to `WeniWebChatCatalog`, `WhatsAppCatalog`, `OneClickPayment`. Added `product_url` to `WebChatProduct`. |
| `weni/broadcasts/__init__.py` | Exported new classes |
| `weni/broadcasts/tests/test_messages.py` | Added tests for both new types + dict shorthand tests |

## Test Coverage

183 tests passing, 98% coverage.