### PR TITLE
feat: add PixPayment message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.6.2] - 2026-04-14
+
+- feat: add PixPayment message
+
 ## [2.6.1] - 2026-04-07
 
 - feat: add OneClickPayment and WhatsAppFlows message types with dict shorthand

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "weni-agents-toolkit"
-version = "2.6.1"
+version = "2.6.2"
 description = ""
 authors = ["Paulo Bernardo <paulo.bernardo@weni.ai>"]
 readme = "README.md"

--- a/weni/broadcasts/__init__.py
+++ b/weni/broadcasts/__init__.py
@@ -3,6 +3,7 @@ from weni.broadcasts.messages import (
     Message,
     OneClickPayment,
     OrderItem,
+    PixPayment,
     QuickReply,
     Text,
     WebChatProduct,
@@ -36,5 +37,6 @@ __all__ = [
     "WhatsAppProductGroup",
     "OneClickPayment",
     "OrderItem",
+    "PixPayment",
     "WhatsAppFlows",
 ]

--- a/weni/broadcasts/messages.py
+++ b/weni/broadcasts/messages.py
@@ -397,3 +397,92 @@ class WhatsAppFlows(Message):
                 "flow_data": self.flow_data,
             },
         }
+
+
+@dataclass
+class PixPayment(Message):
+    """
+    PIX payment message with order details and PIX code.
+
+    Items can be passed as dicts -- no need to import OrderItem.
+
+    Example:
+        ```python
+        Broadcast(self).send(PixPayment(
+            text="Copy the PIX code below to complete payment.",
+            reference_id="1484830849478-01",
+            pix_key="7d4e8f2a-3b1c-4d5e-9f6a-8b7c2d1e0f3a",
+            pix_key_type="EVP",
+            merchant_name="MY STORE",
+            pix_code="00020126580014br.gov.bcb.pix...",
+            total_amount=34990,
+            items=[{"retailer_id": "31245#1", "name": "Nike Air Max", "amount": 24990}],
+            subtotal=29990,
+        ))
+        ```
+    """
+
+    text: str
+    reference_id: str
+    pix_key: str
+    pix_key_type: str
+    merchant_name: str
+    pix_code: str
+    total_amount: int
+    items: list[OrderItem] = field(default_factory=list)
+    subtotal: int = 0
+    tax_value: int = 0
+    discount_value: int = 0
+    shipping_value: int = 0
+    footer: str | None = None
+
+    def __post_init__(self) -> None:
+        self.items = [
+            OrderItem(**item) if isinstance(item, dict) else item
+            for item in self.items
+        ]
+
+    def format_message(self) -> dict[str, Any]:
+        order_items = []
+        for item in self.items:
+            item_dict: dict[str, Any] = {
+                "retailer_id": item.retailer_id,
+                "name": item.name,
+                "amount": {"value": item.amount, "offset": 100},
+                "quantity": item.quantity,
+            }
+            if item.sale_amount is not None:
+                item_dict["sale_amount"] = {"value": item.sale_amount, "offset": 100}
+            order_items.append(item_dict)
+
+        order: dict[str, Any] = {
+            "items": order_items,
+            "subtotal": self.subtotal,
+            "tax": {"description": "Impostos", "offset": 100, "value": self.tax_value},
+            "discount": {"description": "Desconto", "offset": 100, "value": self.discount_value},
+            "shipping": {"description": "Frete", "offset": 100, "value": self.shipping_value},
+        }
+
+        payload: dict[str, Any] = {
+            "text": self.text,
+            "interaction_type": "order_details",
+            "order_details": {
+                "reference_id": self.reference_id,
+                "payment_settings": {
+                    "type": "digital-goods",
+                    "pix_config": {
+                        "key": self.pix_key,
+                        "key_type": self.pix_key_type,
+                        "merchant_name": self.merchant_name,
+                        "code": self.pix_code,
+                    },
+                },
+                "total_amount": self.total_amount,
+                "order": order,
+            },
+        }
+
+        if self.footer:
+            payload["footer"] = self.footer
+
+        return payload

--- a/weni/broadcasts/tests/test_messages.py
+++ b/weni/broadcasts/tests/test_messages.py
@@ -12,6 +12,7 @@ from weni.broadcasts.messages import (
     WhatsAppProductGroup,
     OneClickPayment,
     OrderItem,
+    PixPayment,
     WhatsAppFlows,
 )
 
@@ -325,3 +326,81 @@ class TestDictShorthand:
 
         assert payload["order_details"]["order"]["items"][0]["retailer_id"] == "SKU-1"
         assert payload["order_details"]["order"]["items"][0]["amount"] == {"value": 10000, "offset": 100}
+
+
+class TestPixPayment:
+    def test_format_basic(self):
+        msg = PixPayment(
+            text="Copy the PIX code to pay.",
+            reference_id="ORDER-001",
+            pix_key="7d4e8f2a-3b1c-4d5e-9f6a-8b7c2d1e0f3a",
+            pix_key_type="EVP",
+            merchant_name="MY STORE",
+            pix_code="00020126580014br.gov.bcb.pix...",
+            total_amount=34990,
+            items=[{"retailer_id": "31245#1", "name": "Nike Air Max", "amount": 24990}],
+            subtotal=29990,
+            discount_value=1500,
+            shipping_value=6500,
+        )
+        payload = msg.format_message()
+
+        assert payload["text"] == "Copy the PIX code to pay."
+        assert payload["interaction_type"] == "order_details"
+        assert "footer" not in payload
+
+        details = payload["order_details"]
+        assert details["reference_id"] == "ORDER-001"
+        assert details["total_amount"] == 34990
+
+        pix = details["payment_settings"]["pix_config"]
+        assert pix["key"] == "7d4e8f2a-3b1c-4d5e-9f6a-8b7c2d1e0f3a"
+        assert pix["key_type"] == "EVP"
+        assert pix["merchant_name"] == "MY STORE"
+        assert pix["code"] == "00020126580014br.gov.bcb.pix..."
+
+        order = details["order"]
+        assert len(order["items"]) == 1
+        assert order["items"][0]["retailer_id"] == "31245#1"
+        assert order["subtotal"] == 29990
+        assert order["discount"]["value"] == 1500
+        assert order["shipping"]["value"] == 6500
+
+    def test_format_with_footer(self):
+        msg = PixPayment(
+            text="Pay now",
+            reference_id="REF-1",
+            pix_key="key",
+            pix_key_type="CPF",
+            merchant_name="Store",
+            pix_code="code",
+            total_amount=1000,
+            items=[{"retailer_id": "1", "name": "Item", "amount": 1000}],
+            subtotal=1000,
+            footer="Thanks for your purchase",
+        )
+        payload = msg.format_message()
+
+        assert payload["footer"] == "Thanks for your purchase"
+
+    def test_format_with_multiple_items(self):
+        msg = PixPayment(
+            text="Pay",
+            reference_id="REF-2",
+            pix_key="key",
+            pix_key_type="EVP",
+            merchant_name="Store",
+            pix_code="code",
+            total_amount=5000,
+            items=[
+                {"retailer_id": "A", "name": "Product A", "amount": 2500, "quantity": 1},
+                {"retailer_id": "B", "name": "Product B", "amount": 2500, "quantity": 2},
+            ],
+            subtotal=5000,
+        )
+        payload = msg.format_message()
+
+        items = payload["order_details"]["order"]["items"]
+        assert len(items) == 2
+        assert items[0]["quantity"] == 1
+        assert items[1]["quantity"] == 2


### PR DESCRIPTION
# feat: add PixPayment message type

## Summary

Adds `PixPayment` broadcast message type for sending PIX payment orders with QR code data via WhatsApp.

## New Message Type

### PixPayment

Sends an order details message with PIX payment configuration, allowing the contact to copy the PIX code and complete payment.

```python
from weni.broadcasts import PixPayment

self.send_broadcast(PixPayment(
    text="Copy the PIX code below to complete payment.",
    reference_id="1484830849478-01",
    pix_key="7d4e8f2a-3b1c-4d5e-9f6a-8b7c2d1e0f3a",
    pix_key_type="EVP",
    merchant_name="CITEROL LTDA",
    pix_code="00020126580014br.gov.bcb.pix...",
    total_amount=34990,
    items=[
        {"retailer_id": "31245#1", "name": "Nike Air Max 90", "amount": 24990},
        {"retailer_id": "78432#1", "name": "Meia Esportiva", "amount": 2500, "quantity": 2},
    ],
    subtotal=29990,
    discount_value=1500,
    shipping_value=6500,
    footer="Obrigado pela preferencia",
))
```

### Fields

| Field | Type | Required | Description |
|-------|------|----------|-------------|
| `text` | str | Yes | Message text displayed to the contact |
| `reference_id` | str | Yes | Order reference ID |
| `pix_key` | str | Yes | PIX key |
| `pix_key_type` | str | Yes | PIX key type (EVP, CPF, CNPJ, etc.) |
| `merchant_name` | str | Yes | Merchant display name |
| `pix_code` | str | Yes | Full PIX copy-paste code |
| `total_amount` | int | Yes | Total amount in cents |
| `items` | list | No | Order items (accepts dicts or OrderItem) |
| `subtotal` | int | No | Subtotal in cents (default: 0) |
| `tax_value` | int | No | Tax in cents (default: 0) |
| `discount_value` | int | No | Discount in cents (default: 0) |
| `shipping_value` | int | No | Shipping in cents (default: 0) |
| `footer` | str | No | Optional footer text |

Items support dict shorthand -- no need to import `OrderItem`.

## Files Changed

| File | Change |
|------|--------|
| `weni/broadcasts/messages.py` | Added `PixPayment` class |
| `weni/broadcasts/__init__.py` | Exported `PixPayment` |
| `weni/broadcasts/tests/test_messages.py` | 3 tests: basic, with footer, multiple items |

## Tests

187 passing, 98% coverage.
