### PR TITLE
chore: release version 2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## [2.8.1] - 2026-07-03
+## [2.8.2] - 2026-08-06
+
+- feat: refresh `context.contact` in place after a successful `Contact.update`, merging the `fields`, `name`, `language`, `groups`, and `urns` returned by Flows so the rest of the execution reads the current contact state
+- fix: record the `contacts_get` and `contacts_updated` operations only after the Flows call succeeds, so a rejected write is no longer reported as if it had happened
+
+## [2.8.1] - 2026-08-03
 
 - feat: change default flows url to be production url
 

--- a/docs/user-guide/contacts.md
+++ b/docs/user-guide/contacts.md
@@ -120,6 +120,24 @@ Each `get()` and `update()` call is recorded in the tool's operation log and inc
 
 These keys only appear in the result when at least one operation was performed.
 
+Entries are recorded **after** the Flows call succeeds. An update rejected by Flows (or a `get()` that finds no contact) raises and leaves the log untouched, so the platform never sees an operation that did not happen.
+
+## Context Refresh
+
+After a successful `update()`, the contact returned by Flows is merged back into `context.contact`, so the rest of the execution reads the current state:
+
+```python
+def execute(self, context: Context):
+    self.contact.update(fields={"email": "user@example.com"})
+    context.contact["fields"]["email"]  # "user@example.com"
+```
+
+Only contact attributes are merged — `fields`, `name`, `language`, `groups`, and `urns`. Platform metadata from the response (`uuid`, `created_on`, `modified_on`, `blocked`, `stopped`) is ignored so the namespace does not drift from what the platform provides.
+
+`fields` is merged key by key, keeping values you did not update. Every other attribute is replaced with the value Flows returned. The refresh reads the response, not the payload you sent, because Flows normalizes values on write.
+
+The refresh applies to the current invocation only. Persisting the change across conversation turns depends on the platform applying the `contacts_updated` log to the session memory.
+
 ## Configuration
 
 Configuration is resolved by `FlowsClient` when `ContactSender` is constructed:

--- a/docs/user-guide/context.md
+++ b/docs/user-guide/context.md
@@ -64,3 +64,23 @@ class ProfileTool(Tool):
         settings: dict[str, Any] = context.globals.get("settings", {})
         api_key: Optional[str] = context.credentials.get("api_key")
 ```
+
+## Immutability
+
+Every namespace is exposed as a read-only mapping, so tool code cannot assign to it:
+
+```python
+context.parameters["city"] = "Recife"  # TypeError
+```
+
+The one exception is the `contact` namespace, which Flows integrations refresh in place after a successful write. Following [`self.contact.update(...)`](contacts.md#context-refresh), the updated attributes are readable from the same `context` object:
+
+```python
+class UpdateEmailTool(Tool):
+    def execute(self, context: Context) -> TextResponse:
+        self.contact.update(fields={"email": "user@example.com"})
+        email = context.contact["fields"]["email"]  # "user@example.com"
+        return TextResponse(data={"email": email})
+```
+
+The refresh lasts for the current invocation only. Whether the change is visible on the next conversation turn depends on the platform persisting it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "weni-agents-toolkit"
-version = "2.8.1"
+version = "2.8.2"
 description = ""
 authors = ["Paulo Bernardo <paulo.bernardo@weni.ai>"]
 readme = "README.md"

--- a/weni/contacts/contact.py
+++ b/weni/contacts/contact.py
@@ -34,6 +34,10 @@ class Contact:
 		"update_contact": "_update_contact_compat",
 	}
 
+	# Contact attributes copied back into the context after a write. Platform
+	# metadata returned by Flows (uuid, created_on, modified_on, ...) stays out.
+	CONTEXT_REFRESH_KEYS: tuple[str, ...] = ("fields", "name", "language", "groups", "urns")
+
 	def __init__(self, tool: 'Tool'):
 		self._tool = tool
 
@@ -53,10 +57,9 @@ class Contact:
 			The Flows contact object as a dictionary.
 		"""
 
-		self._tool._register_operation("contacts_get", urn)
 		contact = self._get_sender().get(urn=urn)
+		self._tool._register_operation("contacts_get", urn)
 		return contact
-
 
 	def update(
 		self,
@@ -77,10 +80,25 @@ class Contact:
 		"""
 
 		from weni.contacts.sender import ContactSender
+
 		merged = ContactSender._merge_update_payload(payload, kwargs)
-		self._tool._register_operation("contacts_updated", merged)
 		result = self._get_sender().update(payload=payload, urn=urn, **kwargs)
+		self._tool._register_operation("contacts_updated", merged)
+		self._refresh_context(result)
 		return result
+
+	def _refresh_context(self, contact: dict[str, Any]) -> None:
+		"""
+		Merge the contact returned by Flows back into the tool context.
+
+		Reads from the response rather than the sent payload because Flows
+		normalizes values. Only whitelisted attributes are merged, so the
+		context does not accumulate platform metadata.
+		"""
+
+		patch = {key: contact[key] for key in self.CONTEXT_REFRESH_KEYS if key in contact}
+		if patch:
+			self._tool.context._merge_contact(patch)
 
 	def _update_contact_compat(
 		self,

--- a/weni/contacts/tests/test_contact.py
+++ b/weni/contacts/tests/test_contact.py
@@ -5,8 +5,15 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from weni.contacts.contact import Contact
-from weni.contacts.sender import ContactNotFoundError
+from weni.contacts.sender import ContactNotFoundError, ContactValidationError
 from weni.contacts.tests.conftest import create_context, default_project
+
+
+def tool_with_contact(contact: dict | None = None) -> MagicMock:
+	"""Build a tool double whose context is a real Context, so merges actually happen."""
+	mock_tool = MagicMock()
+	mock_tool.context = create_context(project=default_project(), contact=contact or {})
+	return mock_tool
 
 
 class TestContactFacade:
@@ -77,3 +84,110 @@ class TestContactFacade:
 		Contact(mock_tool).get()
 
 		mock_sender_class.assert_called_once_with(mock_tool.context)
+
+
+class TestContactOperationLog:
+	"""Operations are only logged once the Flows write has succeeded."""
+
+	@patch.object(Contact, '_get_sender')
+	def test_update_does_not_register_operation_when_sender_fails(self, mock_get_sender):
+		mock_get_sender.return_value.update.side_effect = ContactValidationError('invalid')
+		mock_tool = tool_with_contact({'fields': {'email': 'old@example.com'}})
+
+		with pytest.raises(ContactValidationError, match='invalid'):
+			Contact(mock_tool).update(fields={'email': 'new@example.com'})
+
+		mock_tool._register_operation.assert_not_called()
+		assert mock_tool.context.contact == {'fields': {'email': 'old@example.com'}}
+
+	@patch.object(Contact, '_get_sender')
+	def test_update_registers_merged_body_after_success(self, mock_get_sender):
+		mock_get_sender.return_value.update.return_value = {'uuid': 'abc'}
+		mock_tool = tool_with_contact()
+
+		Contact(mock_tool).update({'fields': {'email': 'new@example.com'}}, name='Jane')
+
+		mock_tool._register_operation.assert_called_once_with(
+			'contacts_updated',
+			{'fields': {'email': 'new@example.com'}, 'name': 'Jane'},
+		)
+
+	@patch.object(Contact, '_get_sender')
+	def test_get_does_not_register_operation_when_sender_fails(self, mock_get_sender):
+		mock_get_sender.return_value.get.side_effect = ContactNotFoundError('missing')
+		mock_tool = tool_with_contact()
+
+		with pytest.raises(ContactNotFoundError, match='missing'):
+			Contact(mock_tool).get(urn='whatsapp:5582')
+
+		mock_tool._register_operation.assert_not_called()
+
+	@patch.object(Contact, '_get_sender')
+	def test_get_registers_raw_urn_after_success(self, mock_get_sender):
+		mock_get_sender.return_value.get.return_value = {'uuid': 'abc'}
+		mock_tool = tool_with_contact()
+
+		Contact(mock_tool).get(urn='whatsapp:5582')
+
+		mock_tool._register_operation.assert_called_once_with('contacts_get', 'whatsapp:5582')
+
+
+class TestContactContextRefresh:
+	"""A successful update is reflected by the context for the rest of the execution."""
+
+	@patch.object(Contact, '_get_sender')
+	def test_update_refreshes_context_with_whitelisted_keys_only(self, mock_get_sender):
+		mock_get_sender.return_value.update.return_value = {
+			'uuid': 'contact-uuid',
+			'modified_on': '2026-07-29T00:00:00Z',
+			'blocked': False,
+			'name': 'Jane',
+			'language': 'por',
+			'groups': [{'name': 'Leads'}],
+			'urns': ['whatsapp:5582'],
+			'fields': {'email': 'new@example.com'},
+		}
+		mock_tool = tool_with_contact({'name': 'John', 'fields': {'email': 'old@example.com', 'cpf': '123'}})
+
+		Contact(mock_tool).update(fields={'email': 'new@example.com'})
+
+		assert mock_tool.context.contact == {
+			'name': 'Jane',
+			'language': 'por',
+			'groups': [{'name': 'Leads'}],
+			'urns': ['whatsapp:5582'],
+			'fields': {'email': 'new@example.com', 'cpf': '123'},
+		}
+
+	@patch.object(Contact, '_get_sender')
+	def test_update_reflects_new_field_on_the_context_reference_held_by_execute(self, mock_get_sender):
+		mock_get_sender.return_value.update.return_value = {'uuid': 'abc', 'fields': {'email': 'new@example.com'}}
+		mock_tool = tool_with_contact({'fields': {'email': 'old@example.com'}})
+		context = mock_tool.context
+
+		Contact(mock_tool).update(fields={'email': 'new@example.com'})
+
+		assert context.contact['fields']['email'] == 'new@example.com'
+
+	@patch.object(Contact, '_get_sender')
+	def test_update_contact_shorthand_refreshes_context(self, mock_get_sender):
+		mock_get_sender.return_value.update.return_value = {'fields': {'email': 'new@example.com'}}
+		mock_tool = tool_with_contact({'fields': {'email': 'old@example.com'}})
+
+		result = Contact(mock_tool)._update_contact_compat({'fields': {'email': 'new@example.com'}})
+
+		mock_get_sender.return_value.update.assert_called_once_with(
+			payload={'fields': {'email': 'new@example.com'}},
+			urn=None,
+		)
+		assert result == {'fields': {'email': 'new@example.com'}}
+		assert mock_tool.context.contact['fields']['email'] == 'new@example.com'
+
+	@patch.object(Contact, '_get_sender')
+	def test_update_leaves_context_untouched_when_response_has_no_contact_attributes(self, mock_get_sender):
+		mock_get_sender.return_value.update.return_value = {'uuid': 'abc', 'modified_on': '2026-07-29T00:00:00Z'}
+		mock_tool = tool_with_contact({'fields': {'email': 'old@example.com'}})
+
+		Contact(mock_tool).update(fields={'email': 'new@example.com'})
+
+		assert mock_tool.context.contact == {'fields': {'email': 'old@example.com'}}

--- a/weni/context/context.py
+++ b/weni/context/context.py
@@ -1,13 +1,14 @@
 from types import MappingProxyType
-from typing import Mapping
+from typing import Any, Mapping
 
 
 class Context:
     """
-    An immutable context container for tool execution.
+    A read-only context container for tool execution.
 
-    The Context class provides a thread-safe, immutable container for passing data
-    to tools during execution. It contains three separate namespaces:
+    The Context class provides a container for passing data to tools during
+    execution. Every namespace is exposed as an immutable mapping, so tool code
+    cannot assign to it. It contains the following namespaces:
 
     Attributes:
         credentials (Mapping): Immutable mapping for configured secrets data
@@ -15,6 +16,10 @@ class Context:
         globals (Mapping): Immutable mapping for global configuration values
         contact (Mapping): Immutable mapping for contact data
         constants (Mapping): Immutable mapping for constant values
+
+    The `contact` namespace is the one exception: Flows integrations refresh it
+    in place via `_merge_contact` after a write, so that the rest of the
+    execution reads the current contact state. See that method for details.
     """
 
     credentials: Mapping
@@ -32,3 +37,30 @@ class Context:
         self.contact = MappingProxyType(contact)
         self.project = MappingProxyType(project)
         self.constants = MappingProxyType(constants)
+
+        # Kept so integrations can refresh the contact namespace; the proxy above
+        # is a view over this dict, so merges are visible through self.contact.
+        self._contact_data: dict[str, Any] = contact
+
+    def _merge_contact(self, patch: Mapping[str, Any]) -> None:
+        """
+        Refresh the contact namespace in place with new contact data.
+
+        Called by Flows integrations after a successful contact write - not by
+        tool developers. Mutating in place (instead of rebuilding the Context)
+        keeps the object identity, so the `context` argument received by
+        `Tool.execute` reflects the update as well as `self.context`.
+
+        Dict values are merged into the existing dict (so a partial `fields`
+        payload keeps untouched keys); every other value replaces the current
+        one. The mutation applies to the dict originally passed to `__init__`.
+
+        Args:
+            patch: Contact attributes to merge into the namespace.
+        """
+        for key, value in patch.items():
+            current = self._contact_data.get(key)
+            if isinstance(value, dict) and isinstance(current, dict):
+                current.update(value)
+            else:
+                self._contact_data[key] = value

--- a/weni/context/tests/test_context.py
+++ b/weni/context/tests/test_context.py
@@ -26,6 +26,91 @@ def test_context_initialization():
     assert context.project == project
     assert context.constants == constants
 
+def make_context(contact: dict) -> Context:
+    """Build a Context with the given contact namespace and placeholder values elsewhere."""
+    return Context(
+        credentials={"api_key": "secret123"},
+        parameters={"user_id": "123"},
+        globals={"env": "production"},
+        contact=contact,
+        project={"name": "Project 1", "uuid": "project-uuid"},
+        constants={"INPUT": {"label": "Example"}},
+    )
+
+
+def test_merge_contact_deep_merges_fields():
+    """Merging fields keeps the sibling keys already present"""
+    context = make_context({"name": "John", "fields": {"email": "old@example.com", "cpf": "123"}})
+
+    context._merge_contact({"fields": {"email": "new@example.com"}})
+
+    assert context.contact["fields"] == {"email": "new@example.com", "cpf": "123"}
+
+
+def test_merge_contact_creates_missing_fields():
+    """Merging fields into a contact without them creates the key"""
+    context = make_context({"name": "John"})
+
+    context._merge_contact({"fields": {"email": "new@example.com"}})
+
+    assert context.contact["fields"] == {"email": "new@example.com"}
+
+
+def test_merge_contact_overwrites_scalar_and_list_values():
+    """Non-dict values replace the current value instead of being merged"""
+    context = make_context({"name": "John", "urns": ["tel:+551199999999"], "groups": [{"name": "Leads"}]})
+
+    context._merge_contact({"name": "Jane", "urns": ["tel:+5511888888888"], "groups": []})
+
+    assert context.contact["name"] == "Jane"
+    assert context.contact["urns"] == ["tel:+5511888888888"]
+    assert context.contact["groups"] == []
+
+
+def test_merge_contact_with_empty_patch_is_a_no_op():
+    """An empty patch leaves the contact namespace untouched"""
+    context = make_context({"name": "John", "fields": {"email": "old@example.com"}})
+
+    context._merge_contact({})
+
+    assert context.contact == {"name": "John", "fields": {"email": "old@example.com"}}
+
+
+def test_merge_contact_does_not_touch_other_namespaces():
+    """Only the contact namespace changes"""
+    context = make_context({"name": "John"})
+
+    context._merge_contact({"name": "Jane"})
+
+    assert context.credentials == {"api_key": "secret123"}
+    assert context.parameters == {"user_id": "123"}
+    assert context.globals == {"env": "production"}
+    assert context.project == {"name": "Project 1", "uuid": "project-uuid"}
+    assert context.constants == {"INPUT": {"label": "Example"}}
+
+
+def test_merge_contact_preserves_object_identity():
+    """Another reference to the same Context sees the update, as Tool.execute's argument does"""
+    context = make_context({"fields": {"email": "old@example.com"}})
+    same_context = context
+    contact_proxy = context.contact
+
+    context._merge_contact({"fields": {"email": "new@example.com"}})
+
+    assert same_context.contact["fields"]["email"] == "new@example.com"
+    assert contact_proxy["fields"]["email"] == "new@example.com"
+
+
+def test_merge_contact_mutates_the_original_dict():
+    """The dict handed to the constructor is the one being mutated"""
+    contact = {"fields": {"email": "old@example.com"}}
+    context = make_context(contact)
+
+    context._merge_contact({"fields": {"email": "new@example.com"}, "name": "Jane"})
+
+    assert contact == {"fields": {"email": "new@example.com"}, "name": "Jane"}
+
+
 def test_preprocessor_context_initialization():
     """Test basic preprocessor context initialization with all parameters"""
     params = {"api_key": "secret123"}


### PR DESCRIPTION
- feat: refresh  in place after a successful , merging returned fields to reflect the current contact state.
- fix: log  and  operations only after successful Flows calls to prevent false reporting of rejected writes.
- Updated documentation to clarify context refresh behavior and logging operations.